### PR TITLE
Add an option `-keep-path`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 *.cmx
 *.cmxs
 *.cmxa
+*.cmt
+*.cmti
+ocp-ocamlres.asm
+ocp-ocamlres.byte
+.depend

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,18 @@ PACKAGES=unix,str,pprint,dynlink
    install uninstall \
    doc install-doc uninstall-doc
 
+RUNLIB_ML= \
+  src/oCamlRes.ml
 LIB_ML= \
-  src/oCamlRes.ml \
   src/oCamlResSubFormats.ml \
   src/oCamlResFormats.ml \
   src/oCamlResScanners.ml \
   src/oCamlResRegistry.ml
 BIN_ML= \
   src/oCamlResMain.ml
+RUNLIB_MLI= \
+  src/oCamlRes.mli
 LIB_MLI= \
-  src/oCamlRes.mli \
   src/oCamlResSubFormats.mli \
   src/oCamlResFormats.mli \
   src/oCamlResScanners.mli \
@@ -30,6 +32,14 @@ BIN_CMI = $(filter-out \
              $(patsubst src/%.mli, src/%.cmi, $(BIN_MLI))) \
           $(patsubst src/%.ml, src/%.cmi, $(BIN_ML))
 BIN_CMTI = $(patsubst src/%.mli, src/%.cmti, $(BIN_MLI))
+RUNLIB_CMO = $(patsubst src/%.ml, src/%.cmo, $(RUNLIB_ML))
+RUNLIB_CMX = $(patsubst src/%.ml, src/%.cmx, $(RUNLIB_ML))
+RUNLIB_CMT = $(patsubst src/%.ml, src/%.cmt, $(RUNLIB_ML))
+RUNLIB_CMI = $(filter-out \
+             $(patsubst src/%.ml, src/%.cmi, $(RUNLIB_ML)), \
+             $(patsubst src/%.mli, src/%.cmi, $(RUNLIB_MLI))) \
+          $(patsubst src/%.ml, src/%.cmi, $(RUNLIB_ML))
+RUNLIB_CMTI = $(patsubst src/%.mli, src/%.cmti, $(RUNLIB_MLI))
 LIB_CMO = $(patsubst src/%.ml, src/%.cmo, $(LIB_ML))
 LIB_CMX = $(patsubst src/%.ml, src/%.cmx, $(LIB_ML))
 LIB_CMT = $(patsubst src/%.ml, src/%.cmt, $(LIB_ML))
@@ -40,6 +50,9 @@ LIB_CMI = $(filter-out \
 LIB_CMTI = $(patsubst src/%.mli, src/%.cmti, $(LIB_MLI))
 
 all: \
+  src/ocplib-ocamlres-runtime.cma \
+  src/ocplib-ocamlres-runtime.cmxa \
+  src/ocplib-ocamlres-runtime.cmxs \
   src/ocplib-ocamlres.cma \
   src/ocplib-ocamlres.cmxa \
   src/ocplib-ocamlres.cmxs \
@@ -53,10 +66,10 @@ doc: all $(LIB_MLI)
           -html -d doc \
 	  $(LIB_MLI)
 
-ocp-ocamlres.byte: src/ocplib-ocamlres.cma $(BIN_CMO)
+ocp-ocamlres.byte: src/ocplib-ocamlres-runtime.cma src/ocplib-ocamlres.cma $(BIN_CMO)
 	ocamlfind ocamlc -I src -g -package $(PACKAGES) -linkpkg -o $@ $^
 
-ocp-ocamlres.asm: src/ocplib-ocamlres.cmxa $(BIN_CMX)
+ocp-ocamlres.asm: src/ocplib-ocamlres-runtime.cmxa src/ocplib-ocamlres.cmxa $(BIN_CMX)
 	ocamlfind ocamlopt -I src -g -package $(PACKAGES) -linkpkg -o $@ $^
 
 src/%.cmi src/%.cmti: src/%.mli
@@ -67,6 +80,15 @@ src/%.cmo src/%.cmt src/%.cmi: src/%.ml
 
 src/%.cmx src/%.cmt src/%.cmi: src/%.ml
 	ocamlfind ocamlopt -safe-string -I src -g -c -package $(PACKAGES) $<
+
+src/ocplib-ocamlres-runtime.cma: $(RUNLIB_CMO)
+	ocamlfind ocamlc -a -package $(PACKAGES) $^ -o $@
+
+src/ocplib-ocamlres-runtime.cmxa: $(RUNLIB_CMX)
+	ocamlfind ocamlopt -a -package $(PACKAGES) $^ -o $@
+
+src/ocplib-ocamlres-runtime.cmxs: $(RUNLIB_CMX)
+	ocamlfind ocamlopt -shared -package $(PACKAGES) $^ -o $@
 
 src/ocplib-ocamlres.cma: $(LIB_CMO)
 	ocamlfind ocamlc -a -package $(PACKAGES) $^ -o $@
@@ -79,7 +101,7 @@ src/ocplib-ocamlres.cmxs: $(LIB_CMX)
 
 -include .depend
 .depend:
-	ocamlfind ocamldep -I src -package $(PACKAGES) $(LIB_MLI) $(LIB_ML)  > $@
+	ocamlfind ocamldep -I src -package $(PACKAGES)  $(RUNLIB_MLI) $(RUNLIB_ML) $(LIB_MLI) $(LIB_ML)  > $@
 
 $(BIN_CMO): src/ocplib-ocamlres.cma
 $(BIN_CMX): src/ocplib-ocamlres.cmxa
@@ -88,6 +110,8 @@ install: all
 	ocamlfind install -destdir $(LIBDIR) ocplib-ocamlres \
           src/META \
           src/*ocplib-ocamlres.* \
+          src/*ocplib-ocamlres-runtime.* \
+	  $(RUNLIB_CMI) $(RUNLIB_CMTI) $(RUNLIB_CMT) $(RUNLIB_MLI) $(RUNLIB_ML) \
 	  $(LIB_CMI) $(LIB_CMTI) $(LIB_CMT) $(LIB_MLI) $(LIB_ML)
 	install ocp-ocamlres.asm $(BINDIR)/ocp-ocamlres
 	install ocp-ocamlres.byte $(BINDIR)/ocp-ocamlres.byte

--- a/opam
+++ b/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "ocp-ocamlres"
+version: "dev"
+maintainer: "benjamin@ocamlpro.com"
+authors: "benjamin@ocamlpro.com"
+homepage: "https://github.com/OCamlPro/ocp-ocamlres"
+bug-reports: "https://github.com/OCamlPro/ocp-ocamlres/issues"
+depends: ["ocamlfind" "base-unix" "pprint"]
+available: ocaml-version >= "4.01.0"
+build: [
+  [make "all"]
+  [make "doc"]
+]
+install: [
+  [make "BINDIR=%{bin}%" "LIBDIR=%{lib}%" "install"]
+  [make "DOCDIR=%{doc}%" "install-doc"]
+]
+remove: [
+  [make "BINDIR=%{bin}%" "LIBDIR=%{lib}%" "uninstall"]
+  [make "DOCDIR=%{doc}%" "uninstall-doc"]
+]
+dev-repo: "git://github.com/OCamlPro/ocp-ocamlres"

--- a/src/META
+++ b/src/META
@@ -1,8 +1,17 @@
-version = "0.1"
+version = "0.4"
 description = "Manipulation, injection and extraction of embedded resources"
 
 archive(byte) = "ocplib-ocamlres.cma"
 archive(byte, plugin) = "ocplib-ocamlres.cma"
 archive(native) = "ocplib-ocamlres.cmxa"
 archive(native, plugin) = "ocplib-ocamlres.cmxs"
+requires = "pprint,str,ocplib-ocamlres.runtime"
 exists_if = "ocplib-ocamlres.cma"
+
+package "runtime" (
+  archive(byte) = "ocplib-ocamlres-runtime.cma"
+  archive(byte, plugin) = "ocplib-ocamlres-runtime.cma"
+  archive(native) = "ocplib-ocamlres-runtime.cmxa"
+  archive(native, plugin) = "ocplib-ocamlres-runtime.cmxs"
+  exists_if = "ocplib-ocamlres-runtime.cma"
+)

--- a/src/oCamlRes.ml
+++ b/src/oCamlRes.ml
@@ -211,4 +211,10 @@ module Res = struct
       else dir :: add path data ps
     | first :: ps, _ ->
       first :: add path data ps
+
+  let rec add_prefix path node =
+    match path with
+    | [] -> node
+    | dir :: path -> Dir (dir, [add_prefix path node])
+
 end

--- a/src/oCamlRes.mli
+++ b/src/oCamlRes.mli
@@ -80,4 +80,8 @@ module Res : sig
 
   (** Transforms the data of a tee, potentially changing their type. *)
   val map : ('a -> 'b) -> 'a root -> 'b root
+
+  (** Add a prefix directory to a node. *)
+  val add_prefix : Path.dirs -> 'a node -> 'a node
+
 end

--- a/src/oCamlResMain.ml
+++ b/src/oCamlResMain.ml
@@ -89,6 +89,8 @@ let list_subformats () =
     (subformats ()) ;
   exit 0
 
+let prefixed_file = ref false
+
 (** Prints the version number *)
 let version () =
   Format.printf "0.1\n" ;
@@ -127,7 +129,10 @@ let main () =
     "-ext", Arg.String (fun e -> exts := e :: !exts),
     "\"ext\"&only scan files ending with \".ext\" (can be called more than once)" ;
     "-keep-empty-dirs", Arg.Clear skip_empty_dirs,
-    "keep empty dirs in scanned files"
+    "keep empty dirs in scanned files" ;
+    "-keep-path", Arg.Set prefixed_file,
+    "keep the prefix path in the explicitly listed files" ;
+
   ] ;
   set_format "ocamlres" ;
   (try
@@ -142,11 +147,12 @@ let main () =
     PathFilter.(if !exts = [] then any else has_extension !exts) in
   let postfilter =
     ResFilter.(if !skip_empty_dirs then exclude empty_dir else any) in
+  let prefixed_file = !prefixed_file in
   let module F = (val !format) in
   let root =
     let subformat = OCamlResSubFormats.(module Raw : SubFormat with type t = string) in
     List.fold_left
-      (fun r d -> Res.merge r (scan_unix_dir ~prefilter ~postfilter subformat d))
+      (fun r d -> Res.merge r (scan_unix_dir ~prefilter ~postfilter ~prefixed_file subformat d))
       [] !files in
   F.output root
 

--- a/src/oCamlResScanners.mli
+++ b/src/oCamlResScanners.mli
@@ -49,5 +49,6 @@ end
 (** Import the files from a base directory as a resource store root. *)
 val scan_unix_dir :
   ?prefilter: PathFilter.t -> ?postfilter: 'a ResFilter.t ->
+  ?prefixed_file:bool ->
   (module OCamlResSubFormats.SubFormat with type t = 'a) ->
   string -> 'a Res.root


### PR DESCRIPTION
When a file is explicity passed to the command-line:

```
ocp-ocamlbuild src/mod.cmi
```

The filename was the complete path, including the slashes (e.g. `"src/mod.cmi"`).
By default, the new behaviour is to keep only the basename (e.g. `mod.cmi`).

A new option `-keep-path` allow to keep the path as a hierarchical
structure (a.k.a. `OcamlRes.Res.Dir`) that can be merged with the
commandline-provided directories, e.g.;

```
ocp-ocamlbuild -keep-path src/mod.cmi src/dir/
```